### PR TITLE
Fix if paymentMethod is empty

### DIFF
--- a/view/frontend/web/js/view/billing-address-mixin.js
+++ b/view/frontend/web/js/view/billing-address-mixin.js
@@ -57,7 +57,7 @@ define([
             }
         },
         updateAddresses: function () {
-            if (quote.paymentMethod().method.indexOf('payone') === -1) { // execute parent function for non payone methods
+            if (quote.paymentMethod()?.method.indexOf('payone') === -1) { // execute parent function for non payone methods
                 return this._super();
             }
 


### PR DESCRIPTION
This might happen when you use a 1 step checkout e.g. Swissup Firecheckout or so